### PR TITLE
Update build falgs for 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,1 @@
-%PYTHON% -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option --hdf5="%LIBRARY_PREFIX%"
+%PYTHON% -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option --hdf5="%LIBRARY_PREFIX%" --global-option --native=False --global-option --sse2=True --global-option --avx2=False --global-option --openmp=False

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,1 @@
-ls ${PREFIX}
-ls ${PREFIX}/include
-
-
 $PYTHON -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option "--hdf5=${PREFIX}" --global-option "--native=False" --global-option "--sse2=True" --global-option "--avx2=False" --global-option "--openmp=False" --global-option "--cpp11=False"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,4 +2,4 @@ ls ${PREFIX}
 ls ${PREFIX}/include
 
 
-$PYTHON -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option "--hdf5=${PREFIX}"
+$PYTHON -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option "--hdf5=${PREFIX}" --global-option "--native=False" --global-option "--sse2=True" --global-option "--avx2=False" --global-option "--openmp=False" --global-option "--cpp11=False"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hdf5plugin" %}
-{% set version = "2.0.0" %}
+{% set version = "2.1.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: dcdacb376ebd513b09f864934e4319988b7fbba78474c7dc013d8e2775de06a4
+  sha256: dce81b1cfc370eac8753580f3648526933ce54fa584efac6743633cb99348eaf
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
This PR builds on PR #3 and updates the build options to:
- disable c++11 for Linux, macOS as there is an issue with macOS (https://github.com/silx-kit/hdf5plugin/issues/58). For Windows, it will be used for python3.
- tune build option to build for generic x86_64 cpus (i.e., no native, sse2 on, avx2 off, openmp off)
closes #2

<!--
Please add any other relevant info below:
-->
