### PR TITLE
Update to v2.1.1

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,16 +10,16 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2015python3.6:
-        CONFIG: win_c_compilervs2015python3.6
+      win_c_compilervs2015cxx_compilervs2015python3.6:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.6
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015python3.7:
-        CONFIG: win_c_compilervs2015python3.7
+      win_c_compilervs2015cxx_compilervs2015python3.7:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.7
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
-      win_c_compilervs2015python3.8:
-        CONFIG: win_c_compilervs2015python3.8
+      win_c_compilervs2015cxx_compilervs2015python3.8:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015python3.8
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: True
   steps:

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -6,6 +6,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -6,6 +6,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -6,6 +6,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:

--- a/.ci_support/linux_python3.8.yaml
+++ b/.ci_support/linux_python3.8.yaml
@@ -6,6 +6,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
 docker_image:
 - condaforge/linux-anvil-comp7
 hdf5:

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -8,6 +8,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
 hdf5:
 - 1.10.5
 macos_machine:

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -8,6 +8,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
 hdf5:
 - 1.10.5
 macos_machine:

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -8,6 +8,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
 hdf5:
 - 1.10.5
 macos_machine:

--- a/.ci_support/osx_python3.8.yaml
+++ b/.ci_support/osx_python3.8.yaml
@@ -8,6 +8,10 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '9'
 hdf5:
 - 1.10.5
 macos_machine:

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.6.yaml
@@ -4,6 +4,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2015
 hdf5:
 - 1.10.5
 pin_run_as_build:
@@ -11,7 +13,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.7'
+- '3.6'
 zip_keys:
 - - python
   - c_compiler
+  - cxx_compiler

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.7.yaml
@@ -4,6 +4,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2015
 hdf5:
 - 1.10.5
 pin_run_as_build:
@@ -11,7 +13,8 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- '3.6'
+- '3.7'
 zip_keys:
 - - python
   - c_compiler
+  - cxx_compiler

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.8.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015python3.8.yaml
@@ -4,6 +4,8 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
+cxx_compiler:
+- vs2015
 hdf5:
 - 1.10.5
 pin_run_as_build:
@@ -15,3 +17,4 @@ python:
 zip_keys:
 - - python
   - c_compiler
+  - cxx_compiler

--- a/README.md
+++ b/README.md
@@ -85,24 +85,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.6</td>
+              <td>win_c_compilervs2015cxx_compilervs2015python3.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8454&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5plugin-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.6" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5plugin-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.6" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.7</td>
+              <td>win_c_compilervs2015cxx_compilervs2015python3.7</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8454&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5plugin-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.7" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5plugin-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.7" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015python3.8</td>
+              <td>win_c_compilervs2015cxx_compilervs2015python3.8</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=8454&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5plugin-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015python3.8" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/hdf5plugin-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015python3.8" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,1 @@
-$PYTHON -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option "--hdf5=${PREFIX}" --global-option "--native=False" --global-option "--sse2=True" --global-option "--avx2=False" --global-option "--openmp=False" --global-option "--cpp11=False"
+$PYTHON -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option "--hdf5=${PREFIX}" --global-option "--native=False" --global-option "--sse2=True" --global-option "--avx2=False" --global-option "--openmp=False"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hdf5plugin" %}
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: dce81b1cfc370eac8753580f3648526933ce54fa584efac6743633cb99348eaf
+  sha256: 95f03d9d0ec97c40c4e7e9b0438e981329c74e85f4645787786d72b615a0787d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - {{ compiler("c") }}
+    - {{ compiler('cxx') }}
   host:
     - pip
     - python


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This PR updates the hdf5plugin version to 2.1.1 which fixes C++11 build issues on macOS.
It also enables C++11 build (snappy library) which was previously disabled on macOS and Linux.

<!--
Please add any other relevant info below:
-->
