### PR TITLE
Fixes osx arm64 and use env. var. to pass build options

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_python3.6.____cpython:

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,3 @@
-%PYTHON% -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option --hdf5="%LIBRARY_PREFIX%" --global-option --native=False --global-option --sse2=True --global-option --avx2=False --global-option --openmp=False
+set HDF5PLUGIN_HDF5_DIR=%LIBRARY_PREFIX%
+
+%PYTHON% -m pip install . --no-deps --ignore-installed -vv

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,5 @@
-$PYTHON -m pip install . --no-deps --ignore-installed -vv --global-option "build" --global-option "--hdf5=${PREFIX}" --global-option "--native=False" --global-option "--sse2=True" --global-option "--avx2=False" --global-option "--openmp=False"
+#!/bin/bash
+
+export HDF5PLUGIN_HDF5_DIR=${PREFIX}
+
+$PYTHON -m pip install . --no-deps --ignore-installed -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hdf5plugin" %}
-{% set version = "3.0.0" %}
+{% set version = "3.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8c6f122f2ac23fe59c1f3f7fb636b405f2eded314945ce9a300435bc0006ef1a
+  sha256: 4600dbdbed8b5f8afe81f086b0ee256ca1aea47a17e5431ddd2f136510a9e02f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,12 @@ source:
 
 build:
   number: 0
+  script_env:
+    - HDF5PLUGIN_SSE2=True  # [x86 or ppc64le]
+    - HDF5PLUGIN_SSE2=False  # [not x86 and not ppc64le]
+    - HDF5PLUGIN_NATIVE=False
+    - HDF5PLUGIN_AVX2=False
+    - HDF5PLUGIN_OPENMP=False
 
 requirements:
   build:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -2,4 +2,4 @@ import sys
 import hdf5plugin
 from hdf5plugin.test import run_tests
 
-sys.exit(run_tests())
+sys.exit(0 if run_tests() else 1)

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,5 @@
+import sys
+import hdf5plugin
+from hdf5plugin.test import run_tests
+
+sys.exit(run_tests())


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
closes #24 
<!--
Please add any other relevant info below:
-->

This PR builds on PR ~~#25 (change to v3.1.0)~~ #27 (change to v3.1.1) and :
- Changes the way to pass build options to use env. var. since in mid-term using `--global-option` should stop working
- Enables/Disables SSE2 explicitly since `hdf5plugin` changed the way to handle build options (now setting env. var. or command line options forces the build option).

I don't know if:
```
build:
  script_env:
```
is the recommended way to do so and if it is also possible to pass %LIBRARY_PREFIX% and $PREFIX there to do it all at a single place. I'm happy to update it if there is a better way.