### PR TITLE
Disable BMI2 instructions to improve compatiblity

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,13 @@ source:
   sha256: 58da2df01698be96dc4db6ec1639854b3425aae14bb8a0d6d9e1f9dbbb955c5e
 
 build:
-  number: 0
+  number: 1
   script_env:
     - HDF5PLUGIN_SSE2=True  # [x86 or ppc64le]
     - HDF5PLUGIN_SSE2=False  # [not x86 and not ppc64le]
     - HDF5PLUGIN_NATIVE=False
     - HDF5PLUGIN_AVX2=False
+    - HDF5PLUGIN_BMI2=False
     - HDF5PLUGIN_OPENMP=False
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This PR disables the use of [BMI2 instructions](https://en.wikipedia.org/wiki/X86_Bit_manipulation_instruction_set) when building Zstd to improve compatibilty through the [`HDFPLUGIN_BMI2` env var](https://hdf5plugin.readthedocs.io/en/stable/install.html#available-options)
